### PR TITLE
EDITOR Ortam Değişkeni yerine 'editor' Komutunu kullan

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -458,7 +458,7 @@ task :new do
     erbify(Param[:foliotemplate], source, Param)
 
     # Düzenlemeye gir.
-    sh ENV['EDITOR'], source
+    sh 'editor' , source
   end
 end
 


### PR DESCRIPTION
rake çalıştırıldığında folyo dosyalarını oluşturduktan sonra yeni oluşturulan folyonun markdown dosyasını düzenlemek için `sh ENV['EDITOR']` komutu ile kullanıcının düzenlemesi için sistemde tanımlı editör ile oluşturulan markdown dosyasını açıyor.

Sisteminde varsayılan editör tanımlı olan kullancılarda sorunsuz çalışıyor.

Ancak sisteminde `$EDITOR` tanımlı olmayan kullanıcılarda 

`TypeError: no implicit conversion of nil into String`

şeklinde hata veriyor.

--trace ile çalıştırıldığında hata çıktısı şöyle oluyor:

> TypeError: no implicit conversion of nil into String
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/file_utils.rb:53:in `system'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/file_utils.rb:53:in `sh'
/usr/local/src/github/celilileri/tools/docs/Rakefile:461:in `block in <top (required)>'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `block in execute'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `each'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:250:in `execute'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:194:in `block in invoke_with_call_chain'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:187:in `invoke_with_call_chain'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/task.rb:180:in `invoke'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:152:in `invoke_task'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `block (2 levels) in top_level'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `each'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:108:in `block in top_level'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:117:in `run_with_threads'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:102:in `top_level'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:80:in `block in run'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:178:in `standard_exception_handling'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/lib/rake/application.rb:77:in `run'
/home/sci/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
/home/sci/.rbenv/versions/2.4.0/bin/rake:22:in `load'
/home/sci/.rbenv/versions/2.4.0/bin/rake:22:in `<main>'

EDITOR ortam değişkeni yerine editor komutu kullanılması hata vermesinin önüne geçiyor.